### PR TITLE
l.facebook.com whitelisted

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -311,7 +311,6 @@ incoming.telemetry.mozilla.org
 scripts.mediavine.com
 piwik.grimoire.org
 www.wowvirtualreality.com
-l.facebook.com
 lepodownload.mediatek.com
 4c.9oo91e.com
 binom.topscoupons.com


### PR DESCRIPTION
This breaks some links from Facebook that go to external sites

Also, please enable Issues in this Github so I can report them that way, rather than through pull requests